### PR TITLE
Ensure AWS Lambda function is configured to validate code-signing

### DIFF
--- a/terraform/lambda.tf
+++ b/terraform/lambda.tf
@@ -18,21 +18,62 @@ resource "aws_iam_role" "iam_for_lambda" {
 EOF
 }
 
+resource "aws_signer_signing_profile" "lambda_signing_profile" {
+  platform_id = "AWSLambda-SHA384-ECDSA"
+  signature_validity_period {
+    value = 135
+    type  = "DAYS"
+  }
+  
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_lambda_code_signing_config" "lambda_code_signing" {
+  allowed_publishers {
+    signing_profile_version_arns = [aws_signer_signing_profile.lambda_signing_profile.version_arn]
+  }
+  
+  policies {
+    untrusted_artifact_on_deployment = "Enforce"
+  }
+}
+
+resource "aws_secretsmanager_secret" "lambda_credentials" {
+  name = "${local.resource_prefix.value}-lambda-credentials"
+}
+
+resource "aws_cloudwatch_metric_alarm" "code_signing_failures" {
+  alarm_name          = "lambda-code-signing-failures"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = "1"
+  metric_name         = "CodeSigningValidationFailed"
+  namespace           = "AWS/Lambda"
+  period              = "300"
+  statistic           = "Sum"
+  threshold           = "1"
+  alarm_description   = "This metric monitors failed code signing validations"
+  dimensions = {
+    FunctionName = aws_lambda_function.analysis_lambda.function_name
+  }
+}
+
 resource "aws_lambda_function" "analysis_lambda" {
-  # lambda have plain text secrets in environment variables
   filename      = "resources/lambda_function_payload.zip"
   function_name = "${local.resource_prefix.value}-analysis"
   role          = "${aws_iam_role.iam_for_lambda.arn}"
   handler       = "exports.test"
 
   source_code_hash = "${filebase64sha256("resources/lambda_function_payload.zip")}"
+  
+  code_signing_config_arn = aws_lambda_code_signing_config.lambda_code_signing.arn
 
   runtime = "nodejs12.x"
 
   environment {
     variables = {
-      access_key = "AKIAIOSFODNN7EXAMPLE"
-      secret_key = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
+      SECRETS_MANAGER_ARN = aws_secretsmanager_secret.lambda_credentials.arn
     }
   }
 }


### PR DESCRIPTION

# Qwiet AI AutoFix 

This PR was created automatically by the Qwiet AI AutoFix tool.


Some manual intervention might be required before merging this PR.

## Fix for Finding [65](http://localhost:9090/apps/terraform-demo/vulnerabilities?appId=terraform-demo&findingId=65&scan=1)








<details>
  <summary>Vulnerability Description</summary>
    <br>
    
Ensure AWS Lambda function is configured to validate code-signing

- <b> Severity: </b> 
- <b> CVSS Score: </b> 8.5 ()
- <b> CWE: </b> CWE-: Ensure AWS Lambda function is configured to validate code-signing

</details>



<details>
  <summary>Attack Payloads</summary>
    <br>
    
The AWS Lambda function has two critical security issues:

1. Missing code-signing validation: The Lambda function doesn't implement AWS Signer for validating code packages, making it vulnerable to unauthorized code execution.

2. Exposed credentials: Hard-coded AWS access and secret keys in environment variables.

Recommended fix:
```
resource "aws_lambda_function" "analysis_lambda" {
  filename      = "resources/lambda_function_payload.zip"
  function_name = "${local.resource_prefix.value}-analysis"
  role          = "${aws_iam_role.iam_for_lambda.arn}"
  handler       = "exports.test"
  
  source_code_hash = "${filebase64sha256("resources/lambda_function_payload.zip")}"
  runtime = "nodejs12.x"
  
  code_signing_config_arn = aws_lambda_code_signing_config.example.arn
  
  environment {
    variables = {
      # Use AWS Secrets Manager instead of hardcoded credentials
    }
  }
}
```

</details>



<details>
  <summary>Testcases</summary>
    <br>
    



```java
import org.junit.Before;
import org.junit.Test;
import org.mockito.Mock;
import org.mockito.MockitoAnnotations;
import static org.mockito.Mockito.*;
import static org.junit.Assert.*;

import com.amazonaws.services.lambda.AWSLambda;
import com.amazonaws.services.lambda.model.*;
import com.amazonaws.services.signer.AWSSigner;
import com.amazonaws.services.signer.model.*;
import com.amazonaws.services.secretsmanager.AWSSecretsManager;
import com.amazonaws.services.secretsmanager.model.*;

import java.util.Arrays;
import java.util.Map;
import java.util.HashMap;

public class LambdaCodeSigningTests {
    
    @Mock
    private AWSLambda lambdaClient;
    
    @Mock
    private AWSSigner signerClient;
    
    @Mock
    private AWSSecretsManager secretsManagerClient;
    
    private static final String LAMBDA_FUNCTION_NAME = "test-analysis";
    private static final String SIGNING_PROFILE_ARN = "arn:aws:signer:us-west-2:123456789012:/signing-profiles/test-profile";
    private static final String SIGNING_CONFIG_ARN = "arn:aws:lambda:us-west-2:123456789012:code-signing-config:csc-0123456789";
    private static final String SECRETS_MANAGER_ARN = "arn:aws:secretsmanager:us-west-2:123456789012:secret:lambda-credentials";
    
    @Before
    public void setUp() {
        MockitoAnnotations.initMocks(this);
    }
    
    @Test
    public void testLambdaHasCodeSigningConfigured() {
        // Arrange
        GetFunctionConfigurationRequest request = new GetFunctionConfigurationRequest()
            .withFunctionName(LAMBDA_FUNCTION_NAME);
        
        GetFunctionConfigurationResult result = new GetFunctionConfigurationResult()
            .withCodeSigningConfigArn(SIGNING_CONFIG_ARN);
        
        when(lambdaClient.getFunctionConfiguration(request)).thenReturn(result);
        
        // Act
        GetFunctionConfigurationResult response = lambdaClient.getFunctionConfiguration(request);
        
        // Assert
        assertNotNull("Lambda function should have code signing configured", response.getCodeSigningConfigArn());
        assertEquals("Code signing config ARN should match expected value", 
                    SIGNING_CONFIG_ARN, response.getCodeSigningConfigArn());
        
        verify(lambdaClient).getFunctionConfiguration(request);
    }
    
    @Test
    public void testCodeSigningConfigurationEnforcement() {
        // Arrange
        GetCodeSigningConfigRequest request = new GetCodeSigningConfigRequest()
            .withCodeSigningConfigArn(SIGNING_CONFIG_ARN);
        
        AllowedPublishers allowedPublishers = new AllowedPublishers()
            .withSigningProfileVersionArns(Arrays.asList(SIGNING_PROFILE_ARN));
        
        CodeSigningPolicies policies = new CodeSigningPolicies()
            .withUntrustedArtifactOnDeployment("Enforce");
        
        GetCodeSigningConfigResult result = new GetCodeSigningConfigResult()
            .withCodeSigningConfig(new CodeSigningConfig()
                .withAllowedPublishers(allowedPublishers)
                .withCodeSigningPolicies(policies));
        
        when(lambdaClient.getCodeSigningConfig(request)).thenReturn(result);
        
        // Act
        GetCodeSigningConfigResult response = lambdaClient.getCodeSigningConfig(request);
        
        // Assert
        assertEquals("Code signing should be enforced", 
                   "Enforce", 
                   response.getCodeSigningConfig().getCodeSigningPolicies().getUntrustedArtifactOnDeployment());
        
        assertFalse("Allowed publishers list should not be empty", 
                  response.getCodeSigningConfig().getAllowedPublishers().getSigningProfileVersionArns().isEmpty());
        
        verify(lambdaClient).getCodeSigningConfig(request);
    }
    
    @Test
    public void testLambdaEnvironmentUsesSecretManagerInsteadOfHardcodedCredentials() {
        // Arrange
        GetFunctionConfigurationRequest request = new GetFunctionConfigurationRequest()
            .withFunctionName(LAMBDA_FUNCTION_NAME);
        
        Map<String, String> environmentVariables = new HashMap<>();
        environmentVariables.put("SECRETS_MANAGER_ARN", SECRETS_MANAGER_ARN);
        
        EnvironmentResponse environment = new EnvironmentResponse()
            .withVariables(environmentVariables);
        
        GetFunctionConfigurationResult result = new GetFunctionConfigurationResult()
            .withEnvironment(environment);
        
        when(lambdaClient.getFunctionConfiguration(request)).thenReturn(result);
        
        GetSecretValueRequest secretRequest = new GetSecretValueRequest()
            .withSecretId(SECRETS_MANAGER_ARN);
        
        GetSecretValueResult secretResult = new GetSecretValueResult()
            .withSecretString("{\"access_key\":\"***\",\"secret_key\":\"***\"}");
        
        when(secretsManagerClient.getSecretValue(secretRequest)).thenReturn(secretResult);
        
        // Act
        GetFunctionConfigurationResult lambdaResponse = lambdaClient.getFunctionConfiguration(request);
        
        // Assert
        assertNotNull("Lambda should have environment variables", lambdaResponse.getEnvironment());
        assertTrue("Lambda should reference Secrets Manager", 
                 lambdaResponse.getEnvironment().getVariables().containsKey("SECRETS_MANAGER_ARN"));
        assertFalse("Lambda should not contain hardcoded access_key", 
                   lambdaResponse.getEnvironment().getVariables().containsKey("access_key"));
        assertFalse("Lambda should not contain hardcoded secret_key", 
                   lambdaResponse.getEnvironment().getVariables().containsKey("secret_key"));
        
        verify(lambdaClient).getFunctionConfiguration(request);
    }
}
```

</details>



<details>
  <summary>Commits/Files Changed</summary>
  <br>
  <ul>
    
<li> Changed <b> file <a href="https://github.com/soharab-ai/shiftleft-terraform-demo/pull/11/commits/96073f8373eb5fe52a6984d87b8e651fcb5522d6"> terraform/lambda.tf </a> </b></li>

  </ul>
</details>
